### PR TITLE
:sparkles:feat: 초기 DDL sql문 작성

### DIFF
--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS opu (
                                    updated_at TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
                                    deleted_at TIMESTAMP NULL,
                                    CONSTRAINT fk_opu_creator FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE SET NULL,
-                                   CONSTRAINT fk_opu_category FOREIGN KEY (category_id) REFERENCES opu_category(id) ON DELETE SET NULL,
+                                   CONSTRAINT fk_opu_category FOREIGN KEY (category_id) REFERENCES opu_category(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- 인덱스 (조회패턴에 맞게)
@@ -50,7 +50,7 @@ CREATE INDEX idx_opu_category ON opu(category_id);
 CREATE INDEX idx_opu_shared_created ON opu(is_shared, created_at DESC);
 CREATE INDEX idx_opu_cat_shared_created ON opu(category_id, is_shared, created_at DESC);
 CREATE INDEX idx_opu_member_created ON opu(member_id, created_at DESC);
-CREATE INDEX idx_opu_original ON opu(original_opu_id);
+
 
 
 -- 사용자 OPU 수행 테이블


### PR DESCRIPTION
## 🏷️ 연결 이슈
Closes #36

## 🏷️ PR 유형
✨ Feature → feat: 새로운 기능 (초기 DDL 및 스키마 설계)

## 📝 PR 내용
초기 데이터베이스 스키마(DDL) 를 추가합니다.  

## 🔧 작업 내역 / 수정 사항
### 조회 성능 고려
- OPU: `is_shared + created_at` 등 탐색 최적화 인덱스 추가
- 수행 통계: `member_id + completed_at`, `opu_id + completed_at` 인덱스 설계
- 투두 조회: `member_id + scheduled_date` 인덱스 적용
- 중복 방지: 찜/차단, OPU 카운터 (`member_id, opu_id`) Unique 처리

### 트랜잭션/데이터 정합 대비
- OPU 수행 로그(event) insert 후 → 카운터(counter) 증가 구조
- 외래키 정책 일관화 (`ON DELETE CASCADE`, `SET NULL` 적절히 적용)

스키마 목록
| 테이블 | 설명 |
|---|---|
| `member` | 사용자 |
| `opu_category` | OPU 카테고리 |
| `opu` | 개인/공개 OPU + 복제 관리 |
| `member_opu_event` | OPU 수행 히스토리 |
| `member_opu_counter` | OPU 누적 수행 카운트 |
| `favorite_opu` | 찜한 OPU |
| `blocked_opu` | 차단한 OPU |
| `routine` | 루틴 설정 |
| `routine_schedule` | 루틴 주기 상세 |
| `todo` | 루틴/OPU 기반 투두 |

---

## 📌 참고
<img width="339" height="336" alt="image" src="https://github.com/user-attachments/assets/8cf931da-110b-4341-8a47-e62b5b630852" />

- Flyway로 V1__init.sql이 잘 실행되는거 확인했습니다.
- 알림 관련 테이블은 추후 추가하겠습니다.
- ERD 클라우드에 반영 안되어있는 부분이 많아서 다음 회의까지 반영해둘게요.

---

## ✅ 체크리스트

- [x] DDL 적용 테스트 완료 
- [x] 인덱스 및 FK 정책 검증 완료
- [x] Flyway 실행 성공 확인