### PR TITLE
:heavy_plus_sign:chore: mariaDB와 Flyway migration을 위한 docker-compose 파일 생성

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.8"
+
+services:
+  mariadb:
+    image: mariadb:10.11
+    container_name: opu-mariadb
+    restart: always
+    ports:
+      - "${DB_PORT}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      TZ: Asia/Seoul
+    volumes:
+      - mariadb_data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --max-allowed-packet=64M
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-p${DB_ROOT_PASSWORD}"]
+      interval: 5s
+      retries: 5
+
+  flyway:
+    image: flyway/flyway:11
+    container_name: opu-flyway
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    volumes:
+      - ./src/main/resources/db/migration:/flyway/sql:ro
+    environment:
+      FLYWAY_URL: jdbc:mariadb://mariadb:3306/${DB_NAME}
+      FLYWAY_USER: ${FLYWAY_USER}
+      FLYWAY_PASSWORD: ${FLYWAY_PASSWORD}
+      FLYWAY_BASELINE_ON_MIGRATE: "true"
+      FLYWAY_VALIDATE_ON_MIGRATE: "true"
+    command: migrate
+
+volumes:
+  mariadb_data:


### PR DESCRIPTION
## 🏷️ 연결 이슈

Closes #38 

## 🏷️ PR 유형 (라벨 & 커밋 메시지 매핑)
-   ➕ Chore (추가) → chore: 의존성 추가


## 📝 PR 내용
로컬 개발 환경 일관성을 위해 MariaDB + Flyway 기반 Docker 구성을 추가했습니다.
DB 및 마이그레이션은 Docker 컨테이너에서 처리하도록 했습니다.

## 🔧 작업 내역 / 수정 사항
- docker-compose.yml 추가 (MariaDB, Flyway)
- Flyway 마이그레이션 자동 실행
- .env 기반 DB 설정 적용
- DB schema 마이그레이션 정상 적용 확인
- 로컬 Spring Boot에서 Docker DB 정상 연결 확인

## 📌 참고
실행방법
`docker compose up -d`
로컬 db가 3306포트에 열려있다면 닫고 실행해주세요.
<img width="909" height="231" alt="image" src="https://github.com/user-attachments/assets/aebc509a-d410-4c1c-8c44-f7e173daf227" />

## ✅ 체크리스트
-   [x] 코드 작성 및 테스트 완료
-   [x] 기존 기능 영향 없음 확인