### PR TITLE
✨ feat: 알림 및 사용자 알림 설정 테이블 추가

### DIFF
--- a/src/main/resources/db/migration/V2__create_notification_tables.sql
+++ b/src/main/resources/db/migration/V2__create_notification_tables.sql
@@ -1,36 +1,58 @@
 
---  알림 기록 테이블
-CREATE TABLE IF NOT EXISTS notification (
-                                            id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-                                            member_id BIGINT NOT NULL,
-                                            title VARCHAR(100) NOT NULL,
-    description VARCHAR(255) NOT NULL,
-    is_read BOOLEAN NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+-- 알림 유형 테이블
+CREATE TABLE IF NOT EXISTS notification_type (
+                                                 id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
 
-    CONSTRAINT fk_notification_member
-    FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE
+                                                 code VARCHAR(50) NOT NULL UNIQUE,    -- ALL, MORNING, EVENING, ROUTINE, RANDOM_PICK
+    name VARCHAR(100) NOT NULL,
+    description VARCHAR(255) NULL,
+    default_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    default_time TIME NULL,
+
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE INDEX idx_notification_member ON notification(member_id);
-CREATE INDEX idx_notification_read ON notification(is_read);
-CREATE INDEX idx_notification_created ON notification(created_at);
 
 
-
---  사용자 알림 설정 테이블
+-- 사용자 알림 설정 테이블
 CREATE TABLE IF NOT EXISTS member_notification_setting (
-                                                           member_id BIGINT NOT NULL PRIMARY KEY,
-
-                                                           all_notification_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-                                                           morning_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-                                                           evening_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-                                                           routine_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-                                                           todo_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-                                                           random_pick_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                                                           id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                                                           member_id BIGINT NOT NULL,
+                                                           notification_type_id BIGINT NOT NULL,
+                                                           enabled BOOLEAN NOT NULL DEFAULT TRUE,
 
                                                            updated_at TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
 
-                                                           CONSTRAINT fk_setting_member
-                                                           FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE
+                                                           CONSTRAINT fk_setting_member FOREIGN KEY (member_id)
+    REFERENCES member(id) ON DELETE CASCADE,
+
+    CONSTRAINT fk_setting_type FOREIGN KEY (notification_type_id)
+    REFERENCES notification_type(id) ON DELETE CASCADE,
+
+    UNIQUE KEY uk_member_notification_type (member_id, notification_type_id)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- 알림 테이블
+CREATE TABLE IF NOT EXISTS notification (
+                                            id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                                            member_id BIGINT NOT NULL,
+                                            notification_type_id BIGINT NOT NULL,
+
+                                            title VARCHAR(100) NOT NULL,
+    message VARCHAR(255) NOT NULL,
+    is_read BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    linked_content_id BIGINT NULL,
+    CONSTRAINT fk_notification_member
+    FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
+
+    CONSTRAINT fk_notification_type
+    FOREIGN KEY (notification_type_id) REFERENCES notification_type(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+CREATE INDEX idx_notification_member ON notification(member_id);
+CREATE INDEX idx_notification_type ON notification(notification_type_id);
+CREATE INDEX idx_notification_created ON notification(created_at);


### PR DESCRIPTION
## 🏷️ 연결 이슈
Closes #41

---

## 🏷️ PR 유형
✨ Feature → feat: 새로운 기능

---

## 📝 PR 내용
- 알림(Notification) 및 사용자별 알림 설정(Notification Preference) 테이블 추가
- Flyway 마이그레이션 V2 적용
---

## 🔧 작업 내역 / 수정 사항

- `notification` 테이블 생성
- `member_notification_setting` 테이블 생성
- `V2__create_notification_tables.sql` 마이그레이션 파일 추가
- Docker 환경에서 Flyway 마이그레이션 실행 확인
- `flyway_schema_history`에 V2 정상 적용 확인 
<img width="264" height="223" alt="image" src="https://github.com/user-attachments/assets/ba4463d6-c076-428b-8693-a04aaa72111a" />


-  ERD 수정
<img width="949" height="434" alt="image" src="https://github.com/user-attachments/assets/9489affb-6dcc-4971-985e-eb97b680146f" />

---

## 📌 참고
적용된 마이그레이션 내역 조회 결과

```sql
SELECT version, description, success, installed_on
FROM flyway_schema_history
ORDER BY installed_rank;
```

---

## ✅ 체크리스트
- [x] 코드 작성 및 테스트 완료
- [x] 기존 기능 영향 없음 확인