### PR TITLE
:recycle: refactor: auth 도메인 분리 및 패키지 구조 개선

### DIFF
--- a/src/main/java/com/opu/opube/feature/auth/command/application/controller/AuthController.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/controller/AuthController.java
@@ -1,8 +1,12 @@
-package com.opu.opube.feature.member.command.application.controller;
+package com.opu.opube.feature.auth.command.application.controller;
 
 import com.opu.opube.common.dto.ApiResponse;
-import com.opu.opube.feature.member.command.application.dto.*;
-import com.opu.opube.feature.member.command.application.service.AuthService;
+import com.opu.opube.feature.auth.command.application.dto.request.LoginRequest;
+import com.opu.opube.feature.auth.command.application.dto.request.RefreshTokenRequest;
+import com.opu.opube.feature.auth.command.application.dto.request.RegisterRequest;
+import com.opu.opube.feature.auth.command.application.dto.response.RegisterResponse;
+import com.opu.opube.feature.auth.command.application.dto.response.TokenResponse;
+import com.opu.opube.feature.auth.command.application.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/opu/opube/feature/auth/command/application/controller/DebugJwtController.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/controller/DebugJwtController.java
@@ -1,4 +1,4 @@
-package com.opu.opube.feature.member.command.application.controller;
+package com.opu.opube.feature.auth.command.application.controller;
 
 import com.opu.opube.common.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/opu/opube/feature/auth/command/application/dto/request/LoginRequest.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.opu.opube.feature.member.command.application.dto;
+package com.opu.opube.feature.auth.command.application.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/opu/opube/feature/auth/command/application/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/dto/request/RefreshTokenRequest.java
@@ -1,4 +1,4 @@
-package com.opu.opube.feature.member.command.application.dto;
+package com.opu.opube.feature.auth.command.application.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/src/main/java/com/opu/opube/feature/auth/command/application/dto/request/RegisterRequest.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/dto/request/RegisterRequest.java
@@ -1,4 +1,4 @@
-package com.opu.opube.feature.member.command.application.dto;
+package com.opu.opube.feature.auth.command.application.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/opu/opube/feature/auth/command/application/dto/response/RegisterResponse.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/dto/response/RegisterResponse.java
@@ -1,4 +1,4 @@
-package com.opu.opube.feature.member.command.application.dto;
+package com.opu.opube.feature.auth.command.application.dto.response;
 
 import lombok.*;
 

--- a/src/main/java/com/opu/opube/feature/auth/command/application/dto/response/TokenResponse.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/dto/response/TokenResponse.java
@@ -1,4 +1,4 @@
-package com.opu.opube.feature.member.command.application.dto;
+package com.opu.opube.feature.auth.command.application.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/opu/opube/feature/auth/command/application/service/AuthService.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/service/AuthService.java
@@ -1,13 +1,13 @@
-package com.opu.opube.feature.member.command.application.service;
+package com.opu.opube.feature.auth.command.application.service;
 
 import com.opu.opube.common.email.EmailService;
 import com.opu.opube.common.jwt.JwtEmailTokenProvider;
 import com.opu.opube.common.jwt.JwtTokenProvider;
 import com.opu.opube.exception.BusinessException;
 import com.opu.opube.exception.ErrorCode;
-import com.opu.opube.feature.member.command.application.dto.RefreshTokenRequest;
-import com.opu.opube.feature.member.command.application.dto.RegisterRequest;
-import com.opu.opube.feature.member.command.application.dto.TokenResponse;
+import com.opu.opube.feature.auth.command.application.dto.request.RefreshTokenRequest;
+import com.opu.opube.feature.auth.command.application.dto.request.RegisterRequest;
+import com.opu.opube.feature.auth.command.application.dto.response.TokenResponse;
 import com.opu.opube.feature.member.command.domain.aggregate.Authorization;
 import com.opu.opube.feature.member.command.domain.aggregate.Member;
 import com.opu.opube.feature.member.command.domain.repository.MemberRepository;

--- a/src/main/java/com/opu/opube/feature/auth/command/application/service/RefreshTokenService.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/service/RefreshTokenService.java
@@ -1,4 +1,4 @@
-package com.opu.opube.feature.member.command.application.service;
+package com.opu.opube.feature.auth.command.application.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;


### PR DESCRIPTION
## 🏷️ 연결 이슈  
Closes #52

---

## 🏷️ PR 유형 (라벨 & 커밋 메시지 매핑)
- ♻️ Refactor – 패키지 구조 리팩토링

---

## 📝 PR 내용

기존 `member` 도메인 내부에 혼재되어 있던 인증 관련 로직을  
독립된 `auth` 도메인으로 분리하여 구조 명확성과 유지보수성을 개선했습니다.

---

## 🔧 작업 내역 / 수정 사항

- member 도메인에서 auth 도메인 분리

---

## ✅ 체크리스트

- [x] 코드 작성 및 빌드 성공
- [x] 회원가입/로그인 기능 정상 동작 확인
- [x] Redis refresh token 저장/검증 정상 동작 확