### PR TITLE
[PR] :fire: remove: member_opu_counter 테이블에서 last_completed_at 컬럼 제거

### DIFF
--- a/src/main/resources/db/migration/V4__remove_last_completed_at_column.sql
+++ b/src/main/resources/db/migration/V4__remove_last_completed_at_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE member_opu_counter DROP COLUMN last_completed_at;


### PR DESCRIPTION
## 🏷️ 연결 이슈
Closes #77

## 🏷️ PR 유형 (라벨 & 커밋 메시지 매핑)

-   🔥 Remove → remove: member_opu_counter 테이블에서 last_completed_at 컬럼 제거


## 📝 PR 내용
member_opu_counter 테이블의 last_completed_at 컬럼이
updated_at 컬럼과 역할이 사실상 중복되어 있어 제거하려고 합니다.

## 🔧 작업 내역 / 수정 사항

Flyway 마이그레이션 파일 생성
ALTER TABLE member_opu_counter DROP COLUMN last_completed_at;
