### PR TITLE
[PR] ✨ feat: 로그인한 사용자 비밀번호 변경 기능 구현

### DIFF
--- a/src/main/java/com/opu/opube/feature/auth/command/application/controller/AuthController.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/controller/AuthController.java
@@ -5,12 +5,14 @@ import com.opu.opube.feature.auth.command.application.dto.request.*;
 import com.opu.opube.feature.auth.command.application.dto.response.KakaoLoginResponse;
 import com.opu.opube.feature.auth.command.application.dto.response.RegisterResponse;
 import com.opu.opube.feature.auth.command.application.dto.response.TokenResponse;
+import com.opu.opube.feature.auth.command.application.security.MemberPrincipal;
 import com.opu.opube.feature.auth.command.application.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -95,6 +97,16 @@ public class AuthController {
             @RequestBody ResendVerificationEmailRequest req
     ) {
         authService.resendVerificationEmail(req.getEmail(), backendBaseUrl);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PostMapping("/password/change")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @RequestBody @Valid ChangePasswordRequest req,
+            @AuthenticationPrincipal MemberPrincipal principal
+    ) {
+        Long memberId = principal.getMemberId();
+        authService.changePassword(memberId, req);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/opu/opube/feature/auth/command/application/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/dto/request/ChangePasswordRequest.java
@@ -1,0 +1,9 @@
+package com.opu.opube.feature.auth.command.application.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ChangePasswordRequest {
+    private String oldPassword;
+    private String newPassword;
+}

--- a/src/main/java/com/opu/opube/feature/auth/command/application/service/AuthService.java
+++ b/src/main/java/com/opu/opube/feature/auth/command/application/service/AuthService.java
@@ -502,6 +502,23 @@ public class AuthService {
         }
     }
 
+    @Transactional
+    public void changePassword(Long memberId, ChangePasswordRequest req) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(req.getOldPassword(), member.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD, "기존 비밀번호가 일치하지 않습니다.");
+        }
+
+        if (req.getNewPassword().length() < 8) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD, "비밀번호는 8자 이상이어야 합니다.");
+        }
+
+        member.changePassword(passwordEncoder.encode(req.getNewPassword()));
+        refreshTokenService.delete(memberId);
+    }
+
     private String buildVerificationHtml(String nickname, String verifyUrl) {
         return """
 <html>


### PR DESCRIPTION
## 🏷️ 연결 이슈
Closes #94

## 🏷️ PR 유형 (라벨 & 커밋 메시지 매핑)
-   ✨ Feature → feat: 새로운 기능


## 📝 PR 내용

비밀번호 재설정 기능은 구현되어있는데
로그인한 사용자 대상 비밀번호 변경 기능은 구현되어있지 않아서 생성했습니다

## 🔧 작업 내역 / 수정 사항

-  로그인한 사용자 비밀번호 변경 기능 구현

## 📌 참고
<img width="926" height="404" alt="image" src="https://github.com/user-attachments/assets/84022fbc-31cb-4d00-a6d8-7a73c826511e" />

## ✅ 체크리스트
-   [x] 코드 작성 및 테스트 완료
-   [x] 기존 기능 영향 없음 확인
-   [x] 문서 및 주석 최신화