### PR TITLE
[PR] ✨  feat: 테스트 알림 발송 컨트롤러 추가

### DIFF
--- a/src/main/java/com/opu/opube/feature/notification/command/application/controller/NotificationTestController.java
+++ b/src/main/java/com/opu/opube/feature/notification/command/application/controller/NotificationTestController.java
@@ -1,0 +1,45 @@
+package com.opu.opube.feature.notification.command.application.controller;
+
+import com.opu.opube.common.dto.ApiResponse;
+import com.opu.opube.feature.auth.command.application.security.MemberPrincipal;
+import com.opu.opube.feature.notification.command.application.service.NotificationCommandService;
+import com.opu.opube.feature.notification.command.domain.aggregate.NotificationTypeCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/dev/notifications")
+@Tag(name = "Notification - Dev/Test", description = "개발/테스트용 알림 발송 API (local/dev only)")
+@Profile({"local", "dev"})
+public class NotificationTestController {
+
+    private final NotificationCommandService notificationCommandService;
+
+    @Operation(
+            summary = "테스트 알림 발송 (본인에게)",
+            description = "현재 로그인한 사용자에게 테스트 알림을 1건 발송합니다."
+    )
+    @PostMapping("/test")
+    public ResponseEntity<ApiResponse<Void>> sendTestToMe(
+            @AuthenticationPrincipal
+            @Parameter(hidden = true) MemberPrincipal principal,
+
+            @RequestParam(defaultValue = "TEST") String code,
+            @RequestParam(defaultValue = "테스트 알림") String title,
+            @RequestParam(defaultValue = "SSE/WebPush 확인용") String content
+    ) {
+        Long memberId = principal.getMemberId();
+
+        notificationCommandService.sendNotification(memberId, NotificationTypeCode.MORNING, title, content, null);
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+}


### PR DESCRIPTION
## 🏷️ 연결 이슈

이번 PR과 관련된 이슈 번호를 작성해주세요  
예: Closes #184

## 🏷️ PR 유형 (라벨 & 커밋 메시지 매핑)
-   ✨ Feature → feat: 새로운 기능

## 📝 PR 내용
SSE, WebPush 테스트 알림 발송 api 추가

## 📌 참고
<img width="359" height="134" alt="스크린샷 2025-12-14 오후 2 56 54" src="https://github.com/user-attachments/assets/23356e6e-2460-4b04-b1bc-796de9fc03b7" />

## ✅ 체크리스트

-   [x] 코드 작성 및 테스트 완료
-   [x] 기존 기능 영향 없음 확인
-   [x] 문서 및 주석 최신화