### PR TITLE
:sparkles: feat: jvm 실행 시 timezone 설정 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ COPY ${JAR_FILE} app.jar
 
 # JVM memory config
 ENV JAVA_OPTS="-Xms256m -Xmx512m"
+ENV TZ="Asia/Seoul"
 
 # Docker healthcheck
 HEALTHCHECK --interval=30s --timeout=3s \
   CMD wget -qO- http://localhost:8080/actuator/health || exit 1
 
-ENTRYPOINT ["java","-Duser.timezone=Asia/Seoul","-jar","app.jar"]
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -Duser.timezone=${TZ:-Asia/Seoul} -jar app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ ENV JAVA_OPTS="-Xms256m -Xmx512m"
 HEALTHCHECK --interval=30s --timeout=3s \
   CMD wget -qO- http://localhost:8080/actuator/health || exit 1
 
-ENTRYPOINT ["java","-jar","app.jar"]
+ENTRYPOINT ["java","-Duser.timezone=Asia/Seoul","-jar","app.jar"]


### PR DESCRIPTION
Closes #219 

- 로그에 붙는 시간 설정은 jvm 정책을 따르기 때문에 해당 부분 설정